### PR TITLE
Fix: pull changes from Rootstock 2020-11-12

### DIFF
--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -17,8 +17,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           TRIGGERING_SHA=${GITHUB_PULL_REQUEST_SHA:-$GITHUB_SHA}
-          TRIGGERING_SHA_7=${TRIGGERING_SHA::7}
-          echo "::set-env name=TRIGGERING_SHA_7::$TRIGGERING_SHA_7"
+          echo "TRIGGERING_SHA_7=${TRIGGERING_SHA::7}" >> $GITHUB_ENV
           echo "TRIGGERING_SHA: $TRIGGERING_SHA"
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ci-cache-refs/heads/master
       - name: Install Environment
-        uses: conda-incubator/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: manubot
           environment-file: build/environment.yml

--- a/.github/workflows/manubot.yaml
+++ b/.github/workflows/manubot.yaml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ci-cache-refs/heads/master
       - name: Install Environment
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v1
         with:
           activate-environment: manubot
           environment-file: build/environment.yml

--- a/SETUP.md
+++ b/SETUP.md
@@ -35,7 +35,7 @@ In general, assume that all commands in this setup are case-sensitive.
 **Edit the following commands with your manuscript's information:**
 
 ```sh
-# GitHub username (change from manubot)
+# GitHub username or organization name (change from manubot)
 OWNER=manubot
 # Repository name (change from rootstock)
 REPO=rootstock
@@ -115,7 +115,7 @@ git rm .appveyor.yml
 git rm ci/install.sh
 ```
 
-GitHub Actions is _usually_ able to deploy without any setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
+GitHub Actions is _usually_ able to deploy without any additional setup using the [`GITHUB_TOKEN`](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token) for authentication.
 GitHub Pages deployment using `GITHUB_TOKEN` recently started working on GitHub without an official announcement.
 If it does not work for you after completing this setup, try reselecting "gh-pages branch" as the Source for GitHub Pages in the repository Settings.
 GitHub Pages should now trigger on the next commit.

--- a/USAGE.md
+++ b/USAGE.md
@@ -43,9 +43,11 @@ For easy creation of markdown tables, check out the [Tables Generator](https://w
 Figures can be included with the following markdown:
 
 ```md
+ 
 ![Caption for the example figure.](url_or_path_to_figure){#fig:example-id}
 ```
 
+The blank line before the figure is required.
 Support for figure numbering and citation is provided by [`pandoc-fignos`](https://github.com/tomduck/pandoc-fignos).
 This figure can be cited in the text using `@fig:example-id`.
 In context, a figure citation may look like: `Figure {@fig:example-id}B shows …`.

--- a/build/README.md
+++ b/build/README.md
@@ -20,30 +20,32 @@ To change the options, either edit the YAML files directly or add additional `--
 
 Note: currently, **Windows is not supported**.
 
-Install the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running the following commands from this directory:
+Install the [conda](https://conda.io) environment specified in [`environment.yml`](environment.yml) by running the following commands
+(from the repository's root directory):
 
 ```sh
 # Install the environment
-conda env create --file environment.yml
+conda env create --file build/environment.yml
 ```
 
 If the `manubot` environment is already installed, but needs to be updated to reflect changes to `environment.yml`, use one of the following options:
 
 ```shell
 # option 1: update the existing environment.
-conda env update --file environment.yml
+conda env update --file build/environment.yml
 
 # option 2: remove and reinstall the manubot environment.
 # Slower than option 1, but guarantees a fresh environment.
 conda env remove --name manubot
-conda env create --file environment.yml
+conda env create --file build/environment.yml
 ```
 
 Activate with `conda activate manubot` (assumes `conda` version of [at least](https://github.com/conda/conda/blob/9d759d8edeb86569c25f6eb82053f09581013a2a/CHANGELOG.md#440-2017-12-20) 4.4).
 The environment should successfully install on both Linux and macOS.
 However, it will fail on Windows due to the [`pango`](https://anaconda.org/conda-forge/pango) dependency.
 
-Because the build process is dependent on having the appropriate version of the `manubot` Python package, it is necessary to use the version specified in `environment.yml`.
+Because the build process is dependent on having the appropriate version of the `manubot` Python package,
+it is necessary to use the version specified in `environment.yml`.
 The latest `manubot` release on PyPI may not be compatible with the latest version of this rootstock repository.
 
 ## Building PDFs

--- a/build/build.sh
+++ b/build/build.sh
@@ -35,12 +35,12 @@ pandoc --verbose \
   --defaults=common.yaml \
   --defaults=html.yaml
 
-# Return null if docker command is missing, otherwise return path to docker
-DOCKER_EXISTS="$(command -v docker || true)"
+# Set DOCKER_RUNNING to a non-empty string if docker is running, otherwise null.
+DOCKER_RUNNING="$(docker info &> /dev/null && echo "yes" || true)"
 
 # Create PDF output (unless BUILD_PDF environment variable equals "false")
 # If Docker is not available, use WeasyPrint to create PDF
-if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
+if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_RUNNING" ]; then
   echo >&2 "Exporting PDF manuscript using WeasyPrint"
   if [ -L images ]; then rm images; fi  # if images is a symlink, remove it
   ln -s content/images
@@ -53,7 +53,7 @@ if [ "${BUILD_PDF:-}" != "false" ] && [ -z "$DOCKER_EXISTS" ]; then
 fi
 
 # If Docker is available, use athenapdf to create PDF
-if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_EXISTS" ]; then
+if [ "${BUILD_PDF:-}" != "false" ] && [ -n "$DOCKER_RUNNING" ]; then
   echo >&2 "Exporting PDF manuscript using Docker + Athena"
   if [ "${CI:-}" = "true" ]; then
     # Incease --delay for CI builds to ensure the webpage fully renders, even when the CI server is under high load.

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -9,17 +9,20 @@ dependencies:
   - jinja2=2.11.2
   - jsonschema=3.2.0
   - pandoc=2.9.2
+  - panflute=1.12.5
   - pango=1.40.14
   - pip=20.2
   - psutil=5.7.3
   - python=3.7.8
   - pyyaml=5.3
   - requests=2.24.0
+  - toml=0.10.2
   - watchdog=0.10.3
   - yamllint=1.25.0
   - pip:
     - errorhandler==2.0.1
     - git+https://github.com/manubot/manubot@7c03b4a7d42506b3241e58cd5643a028443b9b9d
+    - isbnlib==3.10.3
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1
     - pandoc-eqnos==2.3.0

--- a/build/environment.yml
+++ b/build/environment.yml
@@ -10,22 +10,22 @@ dependencies:
   - jsonschema=3.2.0
   - pandoc=2.9.2
   - pango=1.40.14
-  - pip=20.0
-  - psutil=5.7.0
-  - python=3.7.6
+  - pip=20.2
+  - psutil=5.7.3
+  - python=3.7.8
   - pyyaml=5.3
-  - requests=2.23.0
-  - watchdog=0.10.2
-  - yamllint=1.21.0
+  - requests=2.24.0
+  - watchdog=0.10.3
+  - yamllint=1.25.0
   - pip:
     - errorhandler==2.0.1
-    - git+https://github.com/manubot/manubot@31968197d1ccd96a46bf092cdba4b575764bb954
+    - git+https://github.com/manubot/manubot@7c03b4a7d42506b3241e58cd5643a028443b9b9d
     - opentimestamps-client==0.7.0
     - opentimestamps==0.4.1
-    - pandoc-eqnos==2.1.1
-    - pandoc-fignos==2.2.0
-    - pandoc-tablenos==2.1.1
-    - pandoc-xnos==2.2.0
+    - pandoc-eqnos==2.3.0
+    - pandoc-fignos==2.3.1
+    - pandoc-tablenos==2.2.2
+    - pandoc-xnos==2.4.3
     - pybase62==0.4.3
     - pysha3==1.0.2
     - python-bitcoinlib==0.10.2

--- a/build/pandoc/defaults/html.yaml
+++ b/build/pandoc/defaults/html.yaml
@@ -2,8 +2,11 @@
 # Load on top of common defaults.
 to: html5
 output-file: output/manuscript.html
+# include-before-body:
+# - build/plugins/d3.html
 include-after-body:
 - build/themes/default.html
+# - build/plugins/inline-svg.html
 - build/plugins/anchors.html
 - build/plugins/accordion.html
 - build/plugins/tooltips.html

--- a/build/plugins/d3.html
+++ b/build/plugins/d3.html
@@ -1,0 +1,16 @@
+<!-- d3 plugin -->
+
+<script
+    src="https://cdnjs.cloudflare.com/ajax/libs/d3/6.2.0/d3.min.js"
+    integrity="sha512-C2RveGuPIWqkaLAluvoxyiaN1XYNe5ss11urhZWZYBUA9Ydgj+hfGKPcxCzTwut1/fmjEZR7Ac35f2aycT8Ogw=="
+    crossorigin="anonymous"
+>
+    // /////////////////////////
+    // DESCRIPTION
+    // /////////////////////////
+
+    // This third-party plugin 'D3' allows you to create complex, dynamic,
+    // interactive, data-driven visualizations in SVG.
+
+    // https://d3js.org/
+</script>

--- a/build/plugins/inline-svg.html
+++ b/build/plugins/inline-svg.html
@@ -1,0 +1,62 @@
+<!-- inline svg plugin -->
+
+<script>
+  (function() {
+      // /////////////////////////
+      // DESCRIPTION
+      // /////////////////////////
+
+      // This Manubot plugin fetches the text source code of SVGs in <img> tags,
+      // and inserts it into the document in-place. This provides many
+      // advantages, such as being able to style SVGs globally from the CSS
+      // themes, and being able to make SVGs interactive with JavaScript and D3.
+      // If you have a script that expects SVGs to be inlined, wait for an
+      // "SVGLoaded" event before running it.
+
+      // Note: This requires the page to be served from a server to work
+      // See: https://stackoverflow.com/a/11063963/2180570
+      // Tip: Use the manubot commands to open the page in a local webserver
+      // See: https://github.com/manubot/rootstock#local-execution
+
+      // /////////////////////////
+      // SCRIPT
+      // /////////////////////////
+
+      // start script
+      async function start() {
+          // get all <img> tags that have "src" attributes that end with ".svg"
+          const imgs = document.querySelectorAll('img[src$=".svg"]');
+          const inlineSvgs = Array.from(imgs).map(inlineSvg);
+          await Promise.all(inlineSvgs);
+
+          // dispatch "inline finished" event
+          document.dispatchEvent(new Event('SVGLoaded'));
+      }
+
+      // take an svg <img> tag, fetch its source code, and replace it 
+      async function inlineSvg(img) {
+          try {
+              // fetch svg source code
+              const response = await fetch(img.src);
+              if (!response.ok) throw new Error('Couldn\'t get SVG source');
+              const source = await response.text();
+              if (!source.trim()) throw new Error('No SVG source');
+              // parse specifically as svg, create new (hidden) dom node
+              const svg = new DOMParser()
+                  .parseFromString(source, 'image/svg+xml')
+                  .querySelector('svg');
+              if (!svg) throw new Error('Couldn\'t parse SVG');
+              // transfer original img attributes into new svg
+              for (const { name, value } of img.attributes)
+                  svg.setAttribute(name, value);
+              // replace original image with new svg
+              img.outerHTML = svg.outerHTML;
+          } catch (error) {
+              console.log(error);
+          }
+      }
+
+      // start script when document is finished loading
+      window.addEventListener('load', start);
+  })();
+</script>

--- a/build/plugins/math.html
+++ b/build/plugins/math.html
@@ -12,8 +12,8 @@
 <!-- mathjax plugin -->
 
 <script
-    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-MML-AM_CHTML.js"
-    integrity="sha512-sRJwTwSmIAJfESgwGDn84X0s72u/n6qBjPShCGXi307x3ZFynu/u2A8652KZhmvjP0U0zeOFCxoMtj9imy9nOQ=="
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML"
+    integrity="sha512-0doc9hKxR3PYwso42RD1p5ySZpzzuDiOwMrdCEh2WdJZCjcmFKc/wEnL+z8fBQrnHoiNWbo+3fiGkOYXBdQp4A=="
     crossorigin="anonymous"
 >
     // /////////////////////////

--- a/build/plugins/math.html
+++ b/build/plugins/math.html
@@ -1,4 +1,4 @@
-<!-- math plugin configuration -->
+<!-- mathjax plugin configuration -->
 
 <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
@@ -6,12 +6,16 @@
         "HTML-CSS": { linebreaks: { automatic: true } },
         "SVG": { linebreaks: { automatic: true } },
         "fast-preview": { disabled: true }
-    });
+  });
 </script>
 
-<!-- math plugin -->
+<!-- mathjax plugin -->
 
-<script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML'>
+<script
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/config/TeX-MML-AM_CHTML.js"
+    integrity="sha512-sRJwTwSmIAJfESgwGDn84X0s72u/n6qBjPShCGXi307x3ZFynu/u2A8652KZhmvjP0U0zeOFCxoMtj9imy9nOQ=="
+    crossorigin="anonymous"
+>
     // /////////////////////////
     // DESCRIPTION
     // /////////////////////////

--- a/build/plugins/table-of-contents.html
+++ b/build/plugins/table-of-contents.html
@@ -1,5 +1,3 @@
-<!-- table of contents plugin -->
-
 <script>
     (function() {
         // /////////////////////////
@@ -22,10 +20,13 @@
             // which types of elements to add links for, in
             // "document.querySelector" format
             typesQuery: 'h1, h2, h3',
-            // whether default behavior is to be closed ('false'), open
-            // ('true'), or only open when screen wide enough to fit panel
-            // ('auto'). note: still always starts closed when page loads.
-            open: 'auto',
+            // whether toc starts open. use 'true' or 'false', or 'auto' to
+            // use 'true' behavior when screen wide enough and 'false' when not
+            startOpen: 'false',
+            // whether toc closes when clicking on toc link. use 'true' or
+            // 'false', or 'auto' to use 'false' behavior when screen wide
+            // enough and 'true' when not
+            clickClose: 'auto',
             // if list item is more than this many characters, text will be
             // truncated
             charLimit: '50',
@@ -50,13 +51,21 @@
             if (!panel)
                 return;
             makeEntries(panel);
+            // attach panel to document after making entries, so 'toc' heading
+            // in panel isn't included in toc
             document.body.insertBefore(panel, document.body.firstChild);
 
-            closePanel();
+            // initial panel state
+            if (
+                options.startOpen === 'true' ||
+                (options.startOpen === 'auto' && !isSmallScreen())
+            )
+                openPanel();
+            else
+                closePanel();
 
             // attach click, scroll, and hash change listeners to window
             window.addEventListener('click', onClick);
-            window.addEventListener('touchstart', onClick);
             window.addEventListener('scroll', onScroll);
             window.addEventListener('hashchange', onScroll);
             window.addEventListener('keyup', onKeyUp);
@@ -74,25 +83,10 @@
             return window.innerWidth < 816 + 260 * 2;
         }
 
-        // open/close panel based on option and screen size
-        function openOrClosePanel() {
-            if (
-                options.open === 'true' ||
-                (options.open === 'auto' && !isSmallScreen())
-            )
-                openPanel();
-            else
-                closePanel();
-        }
-
         // when mouse is clicked anywhere in window
         function onClick() {
-            const panel = document.getElementById('toc_panel');
-            if (!panel)
-                return;
-
-            if (panel.dataset.open === 'true')
-                openOrClosePanel();
+            if (isSmallScreen())
+                closePanel();
         }
 
         // when window is scrolled or hash changed
@@ -174,8 +168,8 @@
             button.classList.add('icon_button');
 
             // create header text
-            const text = document.createElement('h3');
-            text.innerHTML = 'View Table of Contents';
+            const text = document.createElement('h4');
+            text.innerHTML = 'Table of Contents';
 
             // create container for toc list
             const list = document.createElement('div');
@@ -252,8 +246,14 @@
         }
 
         // when link is clicked
-        function onLinkClick() {
-            openOrClosePanel();
+        function onLinkClick(event) {
+            if (
+                options.clickClose === 'true' ||
+                (options.clickClose === 'auto' && isSmallScreen())
+            )
+                closePanel();
+            else
+                openPanel();
         }
 
         // open panel if closed, close if opened

--- a/build/themes/default.html
+++ b/build/themes/default.html
@@ -216,7 +216,8 @@
     }
 
     /* figure image element */
-    figure img {
+    figure > img,
+    figure > svg {
         max-width: 100%;
         display: block;
         margin-left: auto;
@@ -224,7 +225,8 @@
     }
 
     /* figure auto-number */
-    img + figcaption > span:first-of-type {
+    img + figcaption > span:first-of-type,
+    svg + figcaption > span:first-of-type {
         font-weight: bold;
         margin-right: 5px;
     }
@@ -804,7 +806,8 @@
         }
 
         /* tooltip copy of <img> */
-        #tooltip_content > figure > img {
+        #tooltip_content > figure > img,
+        #tooltip_content > figure > svg {
             max-height: 260px;
         }
 
@@ -1055,7 +1058,7 @@
 
     @media only screen {
         /* regular <img> in document when hovered */
-        .lightbox_document_img:hover {
+        img.lightbox_document_img:hover {
             cursor: pointer;
         }
 


### PR DESCRIPTION
The CI started erroring due to an [update](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) in Github Actions, so I pulled from the original repo all the changes since we did the fork in July. @dcsoto this maybe is a sign that we should not remove the history as discussed in #7?

The CI is now working fine, once this is merged to master I can merge in turn to the other open PRs (#16 and #17).