### PR TITLE
Pin old version of Markupsafe

### DIFF
--- a/build/environment.yml
+++ b/build/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - cffi=1.12.3
   - ghp-import=0.5.5
   - jinja2=2.11.2
+  - markupsafe=2.0.1
   - jsonschema=3.2.0
   - pandoc=2.9.2
   - panflute=1.12.5


### PR DESCRIPTION
New version of Markup safe breaks with old Jinja version. To work around it, an older version of Markupsafe needs to be manually added (https://github.com/manubot/rootstock/issues/459). I added version 2.0.1 to the environment YAML (https://github.com/pallets/markupsafe/issues/284).